### PR TITLE
Subproject with generic guice bindings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,12 @@ subprojects {
 project(':netflix-commons-util') {
 }
 
+project(':netflix-lifecycle') {
+    dependencies {
+        compile 'com.netflix.governator:governator:1.2.7'
+    }
+}
+
 project(':netflix-infix') {
     dependencies {
         compile 'commons-jxpath:commons-jxpath:1.3'
@@ -51,8 +57,8 @@ project(':netflix-eventbus') {
         compile project(':netflix-infix')
         
         compile 'com.netflix.servo:servo-core:0.5.3'
-        compile 'org.apache.commons:commons-math:2.2'
         compile 'com.netflix.archaius:archaius-core:0.3.3'
+        compile 'org.apache.commons:commons-math:2.2'
     }
 }
 

--- a/netflix-jersey-guice/src/main/java/com/netflix/jersey/guice/providers/exception/ThrowableExceptionMapper.java
+++ b/netflix-jersey-guice/src/main/java/com/netflix/jersey/guice/providers/exception/ThrowableExceptionMapper.java
@@ -32,7 +32,7 @@ import javax.ws.rs.ext.Provider;
  * {@code
  *  new AbstractModule() {
  *      void configuration() {
- *          Multibinder<OptionalExceptionMapper> mappers = Multibinder.newSetBinder(binder(), OptionalExceptionMapper.class);
+ *          Multibinder<CustomThrowableExceptionMapper> mappers = Multibinder.newSetBinder(binder(), CustomThrowableExceptionMapper.class);
  *          mappers.addBinding().to(MyCustomExceptionMapper.class);
  *      }
  *  }

--- a/netflix-lifecycle/src/main/java/com/netflix/lifecycle/concurrency/ConcurrencyModule.java
+++ b/netflix-lifecycle/src/main/java/com/netflix/lifecycle/concurrency/ConcurrencyModule.java
@@ -1,0 +1,26 @@
+package com.netflix.lifecycle.concurrency;
+
+import java.util.concurrent.ScheduledExecutorService;
+
+import javax.inject.Singleton;
+
+import com.google.inject.AbstractModule;
+import com.netflix.governator.annotations.binding.Background;
+
+/**
+ * Provide bindings for concurrency related singletons such as background
+ * executors.  All bindings should be LazySingletons so that they are only 
+ * created when needed.
+ * 
+ * @author elandau
+ *
+ */
+@Singleton
+public class ConcurrencyModule extends AbstractModule {
+    @Override
+    protected void configure() {
+        bind(ScheduledExecutorService.class)
+            .annotatedWith(Background.class)
+            .toProvider(CoreCountBasedScheduledExecutorServiceProvider.class);
+    }
+}

--- a/netflix-lifecycle/src/main/java/com/netflix/lifecycle/concurrency/CoreCountBasedScheduledExecutorServiceProvider.java
+++ b/netflix-lifecycle/src/main/java/com/netflix/lifecycle/concurrency/CoreCountBasedScheduledExecutorServiceProvider.java
@@ -1,0 +1,32 @@
+package com.netflix.lifecycle.concurrency;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+import javax.annotation.PreDestroy;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.google.inject.Provider;
+import com.netflix.governator.guice.lazy.LazySingleton;
+
+@LazySingleton
+public class CoreCountBasedScheduledExecutorServiceProvider implements Provider<ScheduledExecutorService> {
+    private ScheduledExecutorService service;
+    
+    @Override
+    public ScheduledExecutorService get() {
+        service = Executors.newScheduledThreadPool(
+                Runtime.getRuntime().availableProcessors(), 
+                new ThreadFactoryBuilder()
+                    .setDaemon(true)
+                    .setNameFormat("Background-%d")
+                    .build());
+        return service;
+    }
+
+    @PreDestroy
+    protected void shutdown() {
+        if (service != null)
+            service.shutdown();
+    }
+}

--- a/netflix-lifecycle/src/test/java/com/netflix/lifecycle/concurrency/ConcurrencyModuleTest.java
+++ b/netflix-lifecycle/src/test/java/com/netflix/lifecycle/concurrency/ConcurrencyModuleTest.java
@@ -1,0 +1,52 @@
+package com.netflix.lifecycle.concurrency;
+
+import java.util.concurrent.ScheduledExecutorService;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.google.inject.ConfigurationException;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.netflix.governator.annotations.binding.Background;
+import com.netflix.governator.guice.BootstrapBinder;
+import com.netflix.governator.guice.BootstrapModule;
+import com.netflix.governator.guice.LifecycleInjector;
+
+public class ConcurrencyModuleTest {
+    @Test
+    public void backgroundShouldBeInjectable() {
+        Injector injector = LifecycleInjector.builder()
+            .withRootModule(ConcurrencyModule.class)
+            .build()
+            .createInjector();
+
+        ScheduledExecutorService service = injector.getInstance(Key.get(ScheduledExecutorService.class, Background.class));
+    }
+    
+    @Test
+    public void shouldUseOverrideModule() {
+        Injector injector = LifecycleInjector.builder()
+                .withRootModule(ConcurrencyModule.class)
+                .withBootstrapModule(new BootstrapModule() {
+                    @Override
+                    public void configure(BootstrapBinder binder) {
+                        binder.bind(ConcurrencyModule.class).toInstance(new ConcurrencyModule() {
+                            @Override
+                            protected void configure() {
+                            }
+                        });
+                    }
+                })
+                .build()
+                .createInjector();
+
+        try {
+            ScheduledExecutorService service = injector.getInstance(Key.get(ScheduledExecutorService.class, Background.class));
+            Assert.fail("Binding shouldn't exist");
+        }
+        catch (ConfigurationException e) {
+            
+        }
+    }
+}

--- a/netflix-lifecycle/src/test/java/com/netflix/lifecycle/concurrency/CoreCountBasedScheduledExecutorServiceProviderTest.java
+++ b/netflix-lifecycle/src/test/java/com/netflix/lifecycle/concurrency/CoreCountBasedScheduledExecutorServiceProviderTest.java
@@ -1,0 +1,39 @@
+package com.netflix.lifecycle.concurrency;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CoreCountBasedScheduledExecutorServiceProviderTest {
+    @Test
+    public void shouldCallAndShutdown() throws Exception {
+        CoreCountBasedScheduledExecutorServiceProvider provider = new CoreCountBasedScheduledExecutorServiceProvider();
+        final CountDownLatch latch = new CountDownLatch(2);
+        ScheduledFuture<?> future = provider.get().scheduleWithFixedDelay(new Runnable() {
+            @Override
+            public void run() {
+                latch.countDown();
+            }
+        },
+        100, 100, TimeUnit.MILLISECONDS);
+        
+        Assert.assertFalse(future.isDone());
+        latch.await();
+        Assert.assertFalse(future.isDone());
+        
+        provider.shutdown();
+        
+        Assert.assertTrue(future.isDone());
+        
+        
+    }
+    
+    @Test
+    public void shouldNotCrashOnUnusedShutdown() {
+        CoreCountBasedScheduledExecutorServiceProvider provider = new CoreCountBasedScheduledExecutorServiceProvider();
+        provider.shutdown();
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,7 @@
 rootProject.name='netflix-commons' 
 include 'netflix-commons-util'
 include 'netflix-statistics'
+include 'netflix-lifecycle'
 include 'netflix-infix'
 include 'netflix-eventbus'
 include 'netflix-eventbus-bridge'


### PR DESCRIPTION
Added new subproject netflix-lifecycle which will contain guice modules with very generic bindings.  The initial module, ConcurrencyModule will have concurrency related bindings such as a Background ScheduledExecutorService
