### PR TITLE
Made Executor of DataPublisher public

### DIFF
--- a/netflix-statistics/src/main/java/com/netflix/stats/distribution/DataPublisher.java
+++ b/netflix-statistics/src/main/java/com/netflix/stats/distribution/DataPublisher.java
@@ -35,7 +35,7 @@ public class DataPublisher {
 
     private static final String THREAD_NAME = "DataPublisher";
     private static final boolean DAEMON_THREADS = true;
-    private static ScheduledExecutorService sharedExecutor = null;
+    public static ScheduledExecutorService sharedExecutor = null;
 
     private final DataAccumulator accumulator;
     private final long delayMillis;


### PR DESCRIPTION
This allows to implement custom shutdown mechanisms to avoid bugs like:
https://github.com/Netflix/ribbon/issues/348
An improperly shutdown DataPublisher appears to also be part of the issue here:
https://github.com/spring-cloud/spring-cloud-netflix/issues/106