### PR TITLE
remove unnecessary dependency on servlet-api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,6 @@ project(':netflix-infix') {
     dependencies {
         compile 'commons-jxpath:commons-jxpath:1.3'
         compile 'joda-time:joda-time:2.3'
-        compile 'javax.servlet:servlet-api:2.5'
         compile 'org.antlr:antlr-runtime:3.4'
         compile 'com.google.code.findbugs:jsr305:3.0.1'
         compile 'com.google.guava:guava:14.0.1'


### PR DESCRIPTION
I noticed some of our apps that do not use servlets in
any way still had this on the classpath as a transitive
of `eureka-client`. It does not appear to actually be
used by `netflix-infix`.