### PR TITLE
Bumped commons-math version to 3.6.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ project(':netflix-eventbus') {
         
         compile 'com.netflix.servo:servo-core:0.5.3'
         compile 'com.netflix.archaius:archaius-core:0.3.3'
-        compile 'org.apache.commons:commons-math:2.2'
+        compile 'org.apache.commons:commons-math3:3.6.1'
     }
 }
 

--- a/netflix-eventbus/src/main/java/com/netflix/eventbus/impl/AbstractEventBusStats.java
+++ b/netflix-eventbus/src/main/java/com/netflix/eventbus/impl/AbstractEventBusStats.java
@@ -1,10 +1,10 @@
 package com.netflix.eventbus.impl;
 
 import com.netflix.servo.monitor.Monitors;
-import org.apache.commons.math.stat.StatUtils;
-import org.apache.commons.math.stat.descriptive.moment.Mean;
-import org.apache.commons.math.stat.descriptive.moment.StandardDeviation;
-import org.apache.commons.math.stat.descriptive.rank.Percentile;
+import org.apache.commons.math3.stat.StatUtils;
+import org.apache.commons.math3.stat.descriptive.moment.Mean;
+import org.apache.commons.math3.stat.descriptive.moment.StandardDeviation;
+import org.apache.commons.math3.stat.descriptive.rank.Percentile;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 


### PR DESCRIPTION
commons-math 2.2 is ancient and we would really rather not have it as a dependency in our projects.  This PR upgrades the dependency to the latest version - 3.6.1.